### PR TITLE
recv_str: fallback for recv errors

### DIFF
--- a/src/turnstiled.cc
+++ b/src/turnstiled.cc
@@ -552,6 +552,7 @@ static bool recv_str(
         } else if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
             return true;
         }
+        return false;
     }
     outs.append(buf, ret);
     sess.str_left -= ret;


### PR DESCRIPTION
Prior to this commit, `recv_str` would call `recv,` but only handle a few of the possible errors. This commit will fall back to returning false in the case an unexpected error is encountered.

It could be possible that if an unhanded error continues after this point without returning early (or handling some other way), then you can end up with undefined behavior or other weirdness when you start to use the results from the `recv` call. There may be a better way to handle specific errors, maybe even necessary handling, but I figured a `return false` here would be fine as a fallback in the off chance that this happens. 

Thanks for checking this out!