### PR TITLE
harden fd_handle_pipe

### DIFF
--- a/src/turnstiled.cc
+++ b/src/turnstiled.cc
@@ -1130,7 +1130,7 @@ static bool fd_handle_pipe(std::size_t i) {
             if (read(fds[i].fd, &c, 1) != 1) {
                 break;
             }
-            if (c == '\0') {
+            if ((c == '\0') || (lgn->srvstr.size() >= PATH_MAX)) {
                 /* done receiving */
                 done = true;
                 break;


### PR DESCRIPTION
Prior to this commit, fd_handle_pipe did not handle any possible read errors. Also, it was prone to a DOS attack vector where a user can endlessly spam the readiness pipe. turnstiled would hang if this happens, and eventually run out of memory.

This commit limits the maximum amount of characters the readiness pipe is allowed to read in to PATH_MAX (seems like a reasonable max, but may need adjustment). It also adds some error logging for the case where the max is exceeded, as well as for if read returns an error at any point. If the max is exceeded, the ready service is still called as usual, and the value read from the pipe up to that point will be passed. This could lead to issues on the ready service side, but it will allow the user to still log in at least (assuming the ready service isn't critical). Perhaps more should be done to communicate this truncation to the user side, but as of now at least this will prevent the DOS.